### PR TITLE
Custom Ability wording change

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
   
   <div class="cusmodal round panel" style="width: 500px; height: 330px;">
 
-    <h2>Custom Spell Editor</h2><div class="cusmodalbody">
+    <h2>Custom Ability Editor</h2><div class="cusmodalbody">
       <svg class="giant">
       <div>Border Color: <input id="color11" min="0" max="255" type="number"><input id="color12" min="0" max="255" type="number"><input id="color13" min="0" max="255" type="number"><input id="nobox" type="checkbox">No Box
         <br>

--- a/scripts/definitions.js
+++ b/scripts/definitions.js
@@ -990,7 +990,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom1",
    "long": "z]",
-   "text": "Custom spell 1 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 1 (Double Click Menu Icon to Edit)",
    "color": [227,25,25],
    "symbol1": "1"
  }, {
@@ -998,7 +998,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom2",
    "long": "z]",
-   "text": "Custom spell 2 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 2 (Double Click Menu Icon to Edit)",
    "color": [227,126,25],
    "symbol1": "2"
  }, {
@@ -1006,7 +1006,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom3",
    "long": "z]",
-   "text": "Custom spell 3 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 3 (Double Click Menu Icon to Edit)",
    "color": [227,227,25],
    "symbol1": "3"
  }, {
@@ -1014,7 +1014,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom4",
    "long": "z]",
-   "text": "Custom spell 4 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 4 (Double Click Menu Icon to Edit)",
    "color": [126,227,25],
    "symbol1": "4"
  }, {
@@ -1022,7 +1022,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom5",
    "long": "z]",
-   "text": "Custom spell 5 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 5 (Double Click Menu Icon to Edit)",
    "color": [25,227,25],
    "symbol1": "5"
  }, {
@@ -1030,7 +1030,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom6",
    "long": "z]",
-   "text": "Custom spell 6 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 6 (Double Click Menu Icon to Edit)",
    "color": [25,227,126],
    "symbol1": "6"
  }, {
@@ -1038,7 +1038,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom7",
    "long": "z]",
-   "text": "Custom spell 7 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 7 (Double Click Menu Icon to Edit)",
    "color": [25,227,227],
    "symbol1": "7"
  }, {
@@ -1046,7 +1046,7 @@ MOVES = [{
    "cat": "custom",
    "name": "custom8",
    "long": "z]",
-   "text": "Custom spell 8 (Double Click Menu Icon to Edit)",
+   "text": "Custom ability 8 (Double Click Menu Icon to Edit)",
    "color": [25,126,227],
    "symbol1": "8"
  }];

--- a/scripts/definitions.js
+++ b/scripts/definitions.js
@@ -320,7 +320,7 @@ MOVES = [{
    "text": "Teleport Ability Target to this empty location.",
    "color": [102,0,154],
    "color2": [255,255,255],
-   "color3": [192,0,255],
+   "color3": [233,155,255],
    "color4": [0,0,0],
    "symbol1": "\u25cf",
    "symbol2": "\u25e6"
@@ -465,7 +465,7 @@ MOVES = [{
    "cat": "official",
    "name": "beacon",
    "long": "cu]ru:set@pos=Athis",
-   "text": "(Magic) Target unit is teleported to Ability Target.",
+   "text": "(Magic) Teleport unit to Ability Target.",
    "color": [155,20,208],
    "color2": [255,255,255],
    "symbol1": "\u25ef"
@@ -531,7 +531,7 @@ MOVES = [{
    "cat": "official",
    "name": "compel",
    "long": "cs]rn:compel#flag@2(ct]start?mn:move@-1(AWAY)",
-   "text": "(Ranged) Compel enemy unit, making them move in the direction of this ability at the start of each turn, for 3 turns.",
+   "text": "(Ranged) Compel enemy unit, making them move in the direction of this ability at the start of their turn, for 3 turns.",
    "color": [255,63,255],
    "color2": [255,255,255],
    "symbol1": "\u2661"
@@ -799,11 +799,21 @@ MOVES = [{
    "cat": "variation",
    "name": "beaconally",
    "long": "cu]ru:set@pos=Athis",
-   "text": "(Magic) Target ally is teleported to Ability Target.",
+   "text": "(Magic) Teleport ally to Ability Target.",
    "color": [155,20,208],
    "color2": [255,255,255],
    "symbol1": "\u25ef",
    "symbol2": "\u25e6",
+   "hide": true
+ }, {
+   "id": "43b",
+   "cat": "variation",
+   "name": "rangedbeacon",
+   "long": "cu]rn:set@pos=Athis",
+   "text": "(Ranged) Teleport unit to Ability Target.",
+   "color": [155,20,208],
+   "color2": [255,255,255],
+   "symbol1": "\u2316",
    "hide": true
  }, {
    "id": "44a",

--- a/scripts/definitions.js
+++ b/scripts/definitions.js
@@ -760,7 +760,7 @@ MOVES = [{
    "cat": "variation",
    "name": "moveblock",
    "long": "bv]:block@(mn:attack)&(LOSEABILTY)/(mn:move)",
-   "text": "(Passive) Block one melee attack from this location, and lose this ability. \n(Active) Move only.",
+   "text": "(Passive) Block one normal attack from this location, and lose this ability. \n(Active) Move only.",
    "color": [0,0,255],
    "color3": [255,255,255],
    "symbol1": "\u2219",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -42,7 +42,7 @@ if (window.location.search && URLSearchParams) {
         "id": "c" + i,
         "cat": "custom",
         "long": "z]",
-        "text": "Custom spell " + i + " (Double Click Menu Icon to Edit)",
+        "text": "Custom ability " + i + " (Double Click Menu Icon to Edit)",
         "color": [108, 108, 25],
         "symbol1": "0"
       });

--- a/scripts/rewrite.js
+++ b/scripts/rewrite.js
@@ -209,7 +209,7 @@ function changeSpell(i, l) {
   if (curMove.dataset) {
     var id = curMove.dataset.id;
 
-    // If painting over the same spell, skip everything.
+    // If painting over the same ability, skip everything.
     if (mouse.mode == "add" && id == config.id) return; 
 
     // Assuming levMoves[id] exists. If it doesn't, this section shouldn't run to begin with.


### PR DESCRIPTION
This commit contains all the changes in https://github.com/CEOPieceMaker/ceopiecemaker.github.io/pull/7, don't merge both.

Changes all non-internal mentions incorrectly calling abilities spells into their proper wording (see the old ability spellshield for the proper usage of spell).